### PR TITLE
Feature/dnd

### DIFF
--- a/src/main/java/gg/projecteden/nexus/features/chat/alerts/AlertsCommand.java
+++ b/src/main/java/gg/projecteden/nexus/features/chat/alerts/AlertsCommand.java
@@ -38,8 +38,6 @@ public class AlertsCommand extends CustomCommand {
 				.next("&c /alerts delete <word or phrase>").suggest("/alerts delete ")
 				.newline()
 				.next("&c /alerts clear").suggest("/alerts clear")
-				.newline()
-				.next("&c /alerts <mute|unmute|toggle>").suggest("/alerts toggle")
 				.send(player());
 	}
 
@@ -111,24 +109,6 @@ public class AlertsCommand extends CustomCommand {
 		alerts.clear();
 		service.save(alerts);
 		send(PREFIX + "Cleared your alerts");
-	}
-
-	@Path("mute")
-	void mute() {
-		alerts.setMuted(true);
-		send(PREFIX + "Alerts muted");
-	}
-
-	@Path("unmute")
-	void unmute() {
-		alerts.setMuted(false);
-		send(PREFIX + "Alerts unmuted");
-	}
-
-	@Path("toggle")
-	void toggle() {
-		alerts.setMuted(!alerts.isMuted());
-		send(PREFIX + "Alerts " + (alerts.isMuted() ? "" : "un") + "muted");
 	}
 
 	@Path("sound")

--- a/src/main/java/gg/projecteden/nexus/features/chat/commands/MessageCommand.java
+++ b/src/main/java/gg/projecteden/nexus/features/chat/commands/MessageCommand.java
@@ -1,6 +1,7 @@
 package gg.projecteden.nexus.features.chat.commands;
 
 import gg.projecteden.nexus.features.chat.Chat;
+import gg.projecteden.nexus.features.commands.MuteMenuCommand;
 import gg.projecteden.nexus.framework.commands.models.CustomCommand;
 import gg.projecteden.nexus.framework.commands.models.annotations.Aliases;
 import gg.projecteden.nexus.framework.commands.models.annotations.Path;
@@ -8,6 +9,7 @@ import gg.projecteden.nexus.framework.commands.models.events.CommandEvent;
 import gg.projecteden.nexus.models.chat.Chatter;
 import gg.projecteden.nexus.models.chat.ChatterService;
 import gg.projecteden.nexus.models.chat.PrivateChannel;
+import gg.projecteden.nexus.models.mutemenu.MuteMenuUser;
 import lombok.NonNull;
 import org.bukkit.OfflinePlayer;
 
@@ -25,6 +27,9 @@ public class MessageCommand extends CustomCommand {
 	void message(OfflinePlayer to, String message) {
 		if (isSelf(to))
 			error("You cannot message yourself");
+
+		if (MuteMenuUser.hasMuted(to, MuteMenuCommand.MuteMenuProvider.MuteMenuItem.MESSAGES))
+			error(to.getName() + " has messages disabled!");
 
 		PrivateChannel dm = new PrivateChannel(chatter, new ChatterService().get(to));
 		if (isNullOrEmpty(message))

--- a/src/main/java/gg/projecteden/nexus/features/chat/commands/MessageCommand.java
+++ b/src/main/java/gg/projecteden/nexus/features/chat/commands/MessageCommand.java
@@ -1,7 +1,7 @@
 package gg.projecteden.nexus.features.chat.commands;
 
 import gg.projecteden.nexus.features.chat.Chat;
-import gg.projecteden.nexus.features.commands.MuteMenuCommand;
+import gg.projecteden.nexus.features.commands.MuteMenuCommand.MuteMenuProvider.MuteMenuItem;
 import gg.projecteden.nexus.framework.commands.models.CustomCommand;
 import gg.projecteden.nexus.framework.commands.models.annotations.Aliases;
 import gg.projecteden.nexus.framework.commands.models.annotations.Path;
@@ -28,7 +28,7 @@ public class MessageCommand extends CustomCommand {
 		if (isSelf(to))
 			error("You cannot message yourself");
 
-		if (MuteMenuUser.hasMuted(to, MuteMenuCommand.MuteMenuProvider.MuteMenuItem.MESSAGES))
+		if (MuteMenuUser.hasMuted(to, MuteMenuItem.MESSAGES))
 			error(to.getName() + " has messages disabled!");
 
 		PrivateChannel dm = new PrivateChannel(chatter, new ChatterService().get(to));

--- a/src/main/java/gg/projecteden/nexus/features/commands/BoopCommand.java
+++ b/src/main/java/gg/projecteden/nexus/features/commands/BoopCommand.java
@@ -1,5 +1,6 @@
 package gg.projecteden.nexus.features.commands;
 
+import gg.projecteden.nexus.features.commands.MuteMenuCommand.MuteMenuProvider.MuteMenuItem;
 import gg.projecteden.nexus.features.minigames.Minigames;
 import gg.projecteden.nexus.framework.commands.models.CustomCommand;
 import gg.projecteden.nexus.framework.commands.models.annotations.Cooldown;
@@ -54,7 +55,7 @@ public class BoopCommand extends CustomCommand {
 		if (isSelf(booped))
 			error("You cannot boop yourself!");
 
-		if (MuteMenuUser.hasMuted(booped, MuteMenuCommand.MuteMenuProvider.MuteMenuItem.MESSAGES))
+		if (MuteMenuUser.hasMuted(booped, MuteMenuItem.MESSAGES))
 			error(booped.getName() + " has boops disabled!");
 
 		if (Minigames.isMinigameWorld(booper.getWorld()))

--- a/src/main/java/gg/projecteden/nexus/features/commands/BoopCommand.java
+++ b/src/main/java/gg/projecteden/nexus/features/commands/BoopCommand.java
@@ -31,15 +31,16 @@ public class BoopCommand extends CustomCommand {
 	@Description("boop all players")
 	@Permission("group.admin")
 	void boopAll(String message, @Switch(shorthand = 'a') boolean anonymous) {
-		final List<Player> players = OnlinePlayers.where().viewer(player()).get().stream()
-			.filter(player -> !isSelf(player) && !Minigames.isMinigameWorld(player.getWorld()))
-			.toList();
+		final List<Player> players = OnlinePlayers.where().viewer(player()).get().stream().toList();
 
 		if (players.isEmpty())
 			error("No players to boop");
 
-		for (Player player : players)
-			run(player(), player, message, anonymous);
+		for (Player player : players) {
+			try {
+				run(player(), player, message, anonymous);
+			} catch (Exception ignore) {}
+		}
 	}
 
 	@Path("<player> [message...] [--anonymous]")
@@ -55,7 +56,7 @@ public class BoopCommand extends CustomCommand {
 		if (isSelf(booped))
 			error("You cannot boop yourself!");
 
-		if (MuteMenuUser.hasMuted(booped, MuteMenuItem.MESSAGES))
+		if (MuteMenuUser.hasMuted(booped, MuteMenuItem.BOOPS))
 			error(booped.getName() + " has boops disabled!");
 
 		if (Minigames.isMinigameWorld(booper.getWorld()))

--- a/src/main/java/gg/projecteden/nexus/features/commands/BoopCommand.java
+++ b/src/main/java/gg/projecteden/nexus/features/commands/BoopCommand.java
@@ -8,6 +8,7 @@ import gg.projecteden.nexus.framework.commands.models.annotations.Path;
 import gg.projecteden.nexus.framework.commands.models.annotations.Permission;
 import gg.projecteden.nexus.framework.commands.models.annotations.Switch;
 import gg.projecteden.nexus.framework.commands.models.events.CommandEvent;
+import gg.projecteden.nexus.models.mutemenu.MuteMenuUser;
 import gg.projecteden.nexus.models.nickname.Nickname;
 import gg.projecteden.nexus.utils.JsonBuilder;
 import gg.projecteden.nexus.utils.PlayerUtils.OnlinePlayers;
@@ -52,6 +53,9 @@ public class BoopCommand extends CustomCommand {
 
 		if (isSelf(booped))
 			error("You cannot boop yourself!");
+
+		if (MuteMenuUser.hasMuted(booped, MuteMenuCommand.MuteMenuProvider.MuteMenuItem.MESSAGES))
+			error(booped.getName() + " has boops disabled!");
 
 		if (Minigames.isMinigameWorld(booper.getWorld()))
 			error("You cannot boop in minigames!");

--- a/src/main/java/gg/projecteden/nexus/features/commands/DNDCommand.java
+++ b/src/main/java/gg/projecteden/nexus/features/commands/DNDCommand.java
@@ -28,9 +28,9 @@ public class DNDCommand extends CustomCommand implements Listener {
 		service.save(user);
 
 		if (state)
-			send(PREFIX + "Your status is now set to Do Not Disturb! Make sure you manage what's muted in &e/mutemenu&3.");
+			send(PREFIX + "You have &aenabled Do Not Disturb mode! Make sure you manage what's muted in &e/mutemenu&3.");
 		else
-			send(PREFIX + "Your status is no longer set to Do Not Disturb!");
+			send(PREFIX + "You have &cdisabled Do Not Disturb mode!");
 	}
 
 	@EventHandler

--- a/src/main/java/gg/projecteden/nexus/features/commands/DNDCommand.java
+++ b/src/main/java/gg/projecteden/nexus/features/commands/DNDCommand.java
@@ -5,6 +5,7 @@ import gg.projecteden.nexus.framework.commands.models.annotations.Path;
 import gg.projecteden.nexus.framework.commands.models.events.CommandEvent;
 import gg.projecteden.nexus.models.dnd.DNDUser;
 import gg.projecteden.nexus.models.dnd.DNDUserService;
+import gg.projecteden.nexus.utils.PlayerUtils;
 import lombok.NoArgsConstructor;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -13,28 +14,30 @@ import org.bukkit.event.player.PlayerJoinEvent;
 @NoArgsConstructor
 public class DNDCommand extends CustomCommand implements Listener {
 	private static final DNDUserService service = new DNDUserService();
+	private DNDUser user;
 
 	public DNDCommand(CommandEvent event) {
 		super(event);
+		if (isPlayerCommandEvent())
+			user = service.get(player());
 	}
 
 	@Path("[state]")
 	public void toggle(Boolean state) {
-		DNDUser user = service.get(event.getPlayer());
-
 		if (state == null)
 			state = !user.isDnd();
 		user.setDnd(state);
 		service.save(user);
 
 		if (state)
-			send(PREFIX + "You have &aenabled Do Not Disturb mode! Make sure you manage what's muted in &e/mutemenu&3.");
+			send(PREFIX + "You have &aenabled &3Do Not Disturb mode! Make sure you manage what's muted in &e/mutemenu&3.");
 		else
-			send(PREFIX + "You have &cdisabled Do Not Disturb mode!");
+			send(PREFIX + "You have &cdisabled &3Do Not Disturb mode!");
 	}
 
 	@EventHandler
 	public void onJoin(PlayerJoinEvent event) {
-		// TODO
+		if (user.isDnd())
+			PlayerUtils.send(user.getPlayer(), PREFIX + "You currently have Do Not Disturb mode &aenabled&3.");
 	}
 }

--- a/src/main/java/gg/projecteden/nexus/features/commands/DNDCommand.java
+++ b/src/main/java/gg/projecteden/nexus/features/commands/DNDCommand.java
@@ -1,0 +1,40 @@
+package gg.projecteden.nexus.features.commands;
+
+import gg.projecteden.nexus.framework.commands.models.CustomCommand;
+import gg.projecteden.nexus.framework.commands.models.annotations.Path;
+import gg.projecteden.nexus.framework.commands.models.events.CommandEvent;
+import gg.projecteden.nexus.models.dnd.DNDUser;
+import gg.projecteden.nexus.models.dnd.DNDUserService;
+import lombok.NoArgsConstructor;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+
+@NoArgsConstructor
+public class DNDCommand extends CustomCommand implements Listener {
+	private static final DNDUserService service = new DNDUserService();
+
+	public DNDCommand(CommandEvent event) {
+		super(event);
+	}
+
+	@Path("[state]")
+	public void toggle(Boolean state) {
+		DNDUser user = service.get(event.getPlayer());
+
+		if (state == null)
+			state = !user.isDnd();
+		user.setDnd(state);
+		service.save(user);
+
+		if (state)
+			send(PREFIX + "Your status is now set to Do Not Disturb! Make sure you manage what's muted in &e/mutemenu&3.");
+		else
+			send(PREFIX + "Your status is no longer set to Do Not Disturb!");
+	}
+
+	@EventHandler
+	public void onJoin(PlayerJoinEvent event) {
+		// TODO
+	}
+}

--- a/src/main/java/gg/projecteden/nexus/features/commands/DNDCommand.java
+++ b/src/main/java/gg/projecteden/nexus/features/commands/DNDCommand.java
@@ -37,6 +37,7 @@ public class DNDCommand extends CustomCommand implements Listener {
 
 	@EventHandler
 	public void onJoin(PlayerJoinEvent event) {
+		DNDUser user = new DNDUserService().get(event.getPlayer());
 		if (user.isDnd())
 			PlayerUtils.send(user.getPlayer(), PREFIX + "You currently have Do Not Disturb mode &aenabled&3.");
 	}

--- a/src/main/java/gg/projecteden/nexus/features/commands/MuteMenuCommand.java
+++ b/src/main/java/gg/projecteden/nexus/features/commands/MuteMenuCommand.java
@@ -69,7 +69,7 @@ public class MuteMenuCommand extends CustomCommand {
 			JUKEBOX("Custom Jukebox Songs", Material.JUKEBOX, List.of("Custom songs played via &c/jukebox")),
 			CHAT_GAMES("Chat Games", Material.PAPER),
 			TP_REQUESTS("Teleport Requests", Material.ENDER_PEARL),
-			MESSAGES("Boops", Material.BOOK),
+			MESSAGES("Messages", Material.BOOK),
 			BOOPS("Boops", Material.BELL),
 			// Sounds
 			FIRST_JOIN_SOUND("First Join", Material.GOLD_BLOCK, 50),

--- a/src/main/java/gg/projecteden/nexus/features/commands/MuteMenuCommand.java
+++ b/src/main/java/gg/projecteden/nexus/features/commands/MuteMenuCommand.java
@@ -68,6 +68,8 @@ public class MuteMenuCommand extends CustomCommand {
 			QUEUP("QueUp Song Updates", Material.MUSIC_DISC_MALL),
 			JUKEBOX("Custom Jukebox Songs", Material.JUKEBOX, List.of("Custom songs played via &c/jukebox")),
 			CHAT_GAMES("Chat Games", Material.PAPER),
+			TP_REQUESTS("Teleport Requests", Material.ENDER_PEARL),
+			MESSAGES("Messages/Boops", Material.BOOK),
 			// Sounds
 			FIRST_JOIN_SOUND("First Join", Material.GOLD_BLOCK, 50),
 			JOIN_QUIT_SOUNDS("Join/Quit", Material.NOTE_BLOCK, 50),

--- a/src/main/java/gg/projecteden/nexus/features/commands/MuteMenuCommand.java
+++ b/src/main/java/gg/projecteden/nexus/features/commands/MuteMenuCommand.java
@@ -69,7 +69,8 @@ public class MuteMenuCommand extends CustomCommand {
 			JUKEBOX("Custom Jukebox Songs", Material.JUKEBOX, List.of("Custom songs played via &c/jukebox")),
 			CHAT_GAMES("Chat Games", Material.PAPER),
 			TP_REQUESTS("Teleport Requests", Material.ENDER_PEARL),
-			MESSAGES("Messages/Boops", Material.BOOK),
+			MESSAGES("Boops", Material.BOOK),
+			BOOPS("Boops", Material.BELL),
 			// Sounds
 			FIRST_JOIN_SOUND("First Join", Material.GOLD_BLOCK, 50),
 			JOIN_QUIT_SOUNDS("Join/Quit", Material.NOTE_BLOCK, 50),

--- a/src/main/java/gg/projecteden/nexus/features/commands/poof/PoofCommand.java
+++ b/src/main/java/gg/projecteden/nexus/features/commands/poof/PoofCommand.java
@@ -1,5 +1,6 @@
 package gg.projecteden.nexus.features.commands.poof;
 
+import gg.projecteden.nexus.features.commands.MuteMenuCommand;
 import gg.projecteden.nexus.features.events.y2021.bearfair21.BearFair21;
 import gg.projecteden.nexus.framework.commands.models.CustomCommand;
 import gg.projecteden.nexus.framework.commands.models.annotations.Aliases;
@@ -7,6 +8,7 @@ import gg.projecteden.nexus.framework.commands.models.annotations.Path;
 import gg.projecteden.nexus.framework.commands.models.annotations.Redirects.Redirect;
 import gg.projecteden.nexus.framework.commands.models.events.CommandEvent;
 import gg.projecteden.nexus.framework.exceptions.postconfigured.PlayerNotOnlineException;
+import gg.projecteden.nexus.models.mutemenu.MuteMenuUser;
 import gg.projecteden.nexus.models.nerd.Nerd;
 import gg.projecteden.nexus.models.nickname.Nickname;
 import gg.projecteden.nexus.models.poof.Poof;
@@ -60,6 +62,9 @@ public class PoofCommand extends CustomCommand {
 
 		if (!canSee(player(), target))
 			throw new PlayerNotOnlineException(target);
+
+		if (MuteMenuUser.hasMuted(target, MuteMenuCommand.MuteMenuProvider.MuteMenuItem.TP_REQUESTS))
+			error(target.getName() + " has teleport requests disabled!");
 
 		Location targetLocation = Nerd.of(target).getLocation();
 		World targetWorld = targetLocation.getWorld();

--- a/src/main/java/gg/projecteden/nexus/features/commands/poof/PoofCommand.java
+++ b/src/main/java/gg/projecteden/nexus/features/commands/poof/PoofCommand.java
@@ -1,6 +1,6 @@
 package gg.projecteden.nexus.features.commands.poof;
 
-import gg.projecteden.nexus.features.commands.MuteMenuCommand;
+import gg.projecteden.nexus.features.commands.MuteMenuCommand.MuteMenuProvider.MuteMenuItem;
 import gg.projecteden.nexus.features.events.y2021.bearfair21.BearFair21;
 import gg.projecteden.nexus.framework.commands.models.CustomCommand;
 import gg.projecteden.nexus.framework.commands.models.annotations.Aliases;
@@ -63,7 +63,7 @@ public class PoofCommand extends CustomCommand {
 		if (!canSee(player(), target))
 			throw new PlayerNotOnlineException(target);
 
-		if (MuteMenuUser.hasMuted(target, MuteMenuCommand.MuteMenuProvider.MuteMenuItem.TP_REQUESTS))
+		if (MuteMenuUser.hasMuted(target, MuteMenuItem.TP_REQUESTS))
 			error(target.getName() + " has teleport requests disabled!");
 
 		Location targetLocation = Nerd.of(target).getLocation();

--- a/src/main/java/gg/projecteden/nexus/features/commands/poof/PoofHereCommand.java
+++ b/src/main/java/gg/projecteden/nexus/features/commands/poof/PoofHereCommand.java
@@ -1,6 +1,6 @@
 package gg.projecteden.nexus.features.commands.poof;
 
-import gg.projecteden.nexus.features.commands.MuteMenuCommand;
+import gg.projecteden.nexus.features.commands.MuteMenuCommand.MuteMenuProvider.MuteMenuItem;
 import gg.projecteden.nexus.framework.commands.models.CustomCommand;
 import gg.projecteden.nexus.framework.commands.models.annotations.Aliases;
 import gg.projecteden.nexus.framework.commands.models.annotations.Path;
@@ -24,7 +24,7 @@ public class PoofHereCommand extends CustomCommand {
 		if (isSelf(target))
 			error("You cannot poof to yourself");
 
-		if (MuteMenuUser.hasMuted(target, MuteMenuCommand.MuteMenuProvider.MuteMenuItem.TP_REQUESTS))
+		if (MuteMenuUser.hasMuted(target, MuteMenuItem.TP_REQUESTS))
 			error(target.getName() + " has teleport requests disabled!");
 
 		Poof request = new Poof(player(), target, Poof.PoofType.POOF_HERE);

--- a/src/main/java/gg/projecteden/nexus/features/commands/poof/PoofHereCommand.java
+++ b/src/main/java/gg/projecteden/nexus/features/commands/poof/PoofHereCommand.java
@@ -1,9 +1,11 @@
 package gg.projecteden.nexus.features.commands.poof;
 
+import gg.projecteden.nexus.features.commands.MuteMenuCommand;
 import gg.projecteden.nexus.framework.commands.models.CustomCommand;
 import gg.projecteden.nexus.framework.commands.models.annotations.Aliases;
 import gg.projecteden.nexus.framework.commands.models.annotations.Path;
 import gg.projecteden.nexus.framework.commands.models.events.CommandEvent;
+import gg.projecteden.nexus.models.mutemenu.MuteMenuUser;
 import gg.projecteden.nexus.models.nickname.Nickname;
 import gg.projecteden.nexus.models.poof.Poof;
 import gg.projecteden.nexus.models.poof.PoofService;
@@ -21,6 +23,9 @@ public class PoofHereCommand extends CustomCommand {
 	void player(Player target) {
 		if (isSelf(target))
 			error("You cannot poof to yourself");
+
+		if (MuteMenuUser.hasMuted(target, MuteMenuCommand.MuteMenuProvider.MuteMenuItem.TP_REQUESTS))
+			error(target.getName() + " has teleport requests disabled!");
 
 		Poof request = new Poof(player(), target, Poof.PoofType.POOF_HERE);
 		service.save(request);

--- a/src/main/java/gg/projecteden/nexus/features/commands/staff/admin/AccountTransferCommand.java
+++ b/src/main/java/gg/projecteden/nexus/features/commands/staff/admin/AccountTransferCommand.java
@@ -142,7 +142,6 @@ public class AccountTransferCommand extends CustomCommand {
 		@Override
 		protected void transfer(Alerts previous, Alerts current) {
 			previous.getHighlights().forEach(highlight -> current.getHighlights().add(highlight));
-			current.setMuted(previous.isMuted());
 
 			previous.getHighlights().clear();
 		}

--- a/src/main/java/gg/projecteden/nexus/features/crates/models/Crate.java
+++ b/src/main/java/gg/projecteden/nexus/features/crates/models/Crate.java
@@ -6,7 +6,7 @@ import com.gmail.filoghost.holographicdisplays.api.HologramsAPI;
 import com.google.common.util.concurrent.AtomicDouble;
 import gg.projecteden.nexus.Nexus;
 import gg.projecteden.nexus.features.chat.Chat;
-import gg.projecteden.nexus.features.commands.MuteMenuCommand;
+import gg.projecteden.nexus.features.commands.MuteMenuCommand.MuteMenuProvider.MuteMenuItem;
 import gg.projecteden.nexus.features.crates.Crates;
 import gg.projecteden.nexus.features.crates.models.events.CrateSpawnItemEvent;
 import gg.projecteden.nexus.features.menus.MenuUtils;
@@ -347,7 +347,7 @@ public abstract class Crate implements Listener {
 		Chat.Broadcast.all()
 			.prefix("Crates")
 			.message(message)
-			.muteMenuItem(MuteMenuCommand.MuteMenuProvider.MuteMenuItem.CRATES)
+			.muteMenuItem(MuteMenuItem.CRATES)
 			.send();
 	}
 }

--- a/src/main/java/gg/projecteden/nexus/features/listeners/Tab.java
+++ b/src/main/java/gg/projecteden/nexus/features/listeners/Tab.java
@@ -11,6 +11,7 @@ import gg.projecteden.nexus.models.afk.events.AFKEvent;
 import gg.projecteden.nexus.models.badge.BadgeUser.Badge;
 import gg.projecteden.nexus.models.badge.BadgeUserService;
 import gg.projecteden.nexus.models.discord.DiscordUserService;
+import gg.projecteden.nexus.models.dnd.DNDUserService;
 import gg.projecteden.nexus.models.nerd.Nerd;
 import gg.projecteden.nexus.models.nickname.Nickname;
 import gg.projecteden.nexus.utils.LuckPermsUtils;
@@ -131,7 +132,7 @@ public class Tab implements Listener {
 		@AllArgsConstructor
 		public enum Modifier {
 			AFK(player -> new AFKUserService().get(player).isAfk()),
-			DND(player -> false), // TODO
+			DND(player -> new DNDUserService().get(player).isDnd()),
 			LIVE(player -> new BadgeUserService().get(player).owns(Badge.TWITCH) && Twitch.isStreaming(new DiscordUserService().get(player))),
 			VANISHED(player -> Nerd.of(player).isVanished()),
 			;

--- a/src/main/java/gg/projecteden/nexus/models/alerts/Alerts.java
+++ b/src/main/java/gg/projecteden/nexus/models/alerts/Alerts.java
@@ -30,7 +30,6 @@ public class Alerts implements PlayerOwnedObject {
 	@NonNull
 	private UUID uuid;
 	private List<Highlight> highlights = new ArrayList<>();
-	private boolean muted;
 
 	public boolean add(String highlight) {
 		return add(highlight, true);
@@ -70,17 +69,8 @@ public class Alerts implements PlayerOwnedObject {
 		highlights.clear();
 	}
 
-	public boolean isMuted() {
-		return muted;
-	}
-
-	public void setMuted(boolean muted) {
-		this.muted = muted;
-	}
-
 	public void playSound() {
-		if (!isMuted())
-			Jingle.PING.play(PlayerUtils.getPlayer(uuid).getPlayer());
+		Jingle.PING.play(PlayerUtils.getPlayer(uuid).getPlayer());
 	}
 
 	public void tryAlerts(String message) {

--- a/src/main/java/gg/projecteden/nexus/models/dnd/DNDUser.java
+++ b/src/main/java/gg/projecteden/nexus/models/dnd/DNDUser.java
@@ -1,0 +1,28 @@
+package gg.projecteden.nexus.models.dnd;
+
+import dev.morphia.annotations.Converters;
+import dev.morphia.annotations.Entity;
+import dev.morphia.annotations.Id;
+import gg.projecteden.mongodb.serializers.UUIDConverter;
+import gg.projecteden.nexus.models.PlayerOwnedObject;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+import java.util.UUID;
+
+@Data
+@Entity(value = "dnd_user", noClassnameStored = true)
+@NoArgsConstructor
+@AllArgsConstructor
+@RequiredArgsConstructor
+@Converters(UUIDConverter.class)
+public class DNDUser implements PlayerOwnedObject {
+	@Id
+	@NonNull
+	private UUID uuid;
+
+	private boolean dnd;
+}

--- a/src/main/java/gg/projecteden/nexus/models/dnd/DNDUserService.java
+++ b/src/main/java/gg/projecteden/nexus/models/dnd/DNDUserService.java
@@ -1,0 +1,18 @@
+package gg.projecteden.nexus.models.dnd;
+
+import gg.projecteden.mongodb.annotations.PlayerClass;
+import gg.projecteden.nexus.models.MongoService;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+@PlayerClass(DNDUser.class)
+public class DNDUserService extends MongoService<DNDUser> {
+	private final static Map<UUID, DNDUser> cache = new ConcurrentHashMap<>();
+
+	public Map<UUID, DNDUser> getCache() {
+		return cache;
+	}
+
+}


### PR DESCRIPTION
Added Do Not Disturb mode. Toggleable by the /dnd command. When enabled, your presence will be red. Dynamically works with vanish and AFK presences (thank Griffin for that lmao). And if you join while in DND mode, you'll receive a message in chat reminding you of so.

Also added /mutemenu options for teleport requests and messages/boops. Also refactored alerts (removed the toggle feature) to rely on the /mutemenu sound option for it for toggability.